### PR TITLE
サマリーカードのテーマカラーを紫に統一

### DIFF
--- a/KakeiboApp/ContentView.swift
+++ b/KakeiboApp/ContentView.swift
@@ -37,6 +37,7 @@ struct ExpenseCategorySummary: Identifiable {
 struct ContentView: View {
     @State private var transactions: [Transaction] = []
     @State private var showingAddSheet = false
+    private let summaryColor = Color.purple
     
     var totalIncome: Double {
         transactions.filter { $0.isIncome }.reduce(0) { $0 + $1.amount }
@@ -79,9 +80,9 @@ struct ContentView: View {
             VStack {
                 // サマリー表示
                 HStack(spacing: 30) {
-                    SummaryCard(title: "収入", amount: totalIncome, color: .green)
-                    SummaryCard(title: "支出", amount: totalExpense, color: .red)
-                    SummaryCard(title: "残高", amount: balance, color: .blue)
+                    SummaryCard(title: "収入", amount: totalIncome, color: summaryColor)
+                    SummaryCard(title: "支出", amount: totalExpense, color: summaryColor)
+                    SummaryCard(title: "残高", amount: balance, color: summaryColor)
                 }
                 .padding()
                 


### PR DESCRIPTION
### Motivation
- ホーム画面のサマリー（収入／支出／残高）カードの色を紫に統一して視認性とデザインの一貫性を高めるため。

### Description
- `KakeiboApp/ContentView.swift` に `private let summaryColor = Color.purple` を追加し、各 `SummaryCard` の色指定を既存の `.green`/`.red`/`.blue` から `summaryColor` に置き換えました。

### Testing
- 自動テストは実行しておらず、変更はファイル更新とローカルでのコミットのみ行いました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ed1920d8c8321a150f5d17ce33361)